### PR TITLE
msm8996-common: use camera focus fix only when supported

### DIFF
--- a/devicesettings/src/org/lineageos/settings/device/SettingsUtils.java
+++ b/devicesettings/src/org/lineageos/settings/device/SettingsUtils.java
@@ -48,6 +48,7 @@ public class SettingsUtils {
     public static final String PREFERENCES = "SettingsUtilsPreferences";
 
     public static void writeCameraFocusFixSysfs(boolean enabled) {
+        if (!supportsCameraFocusFix()) return;
         try {
             FileOutputStream out = new FileOutputStream(new File(CAMERA_FOCUS_FIX_SYSFS));
             OutputStreamWriter writer = new OutputStreamWriter(out);


### PR DESCRIPTION
In BootCompletedReceiver class there is no check whether camera focus fix is supported or not:
    public void onReceive(final Context context, Intent intent) {
        if (DEBUG) Log.d(TAG, "Boot Receiver");
        SettingsUtils.writeCameraFocusFixSysfs(
            SettingsUtils.getCameraFocusFixEnabled(context));
    }
It is better to prevent SettingsUtils.writeCameraFocusFixSysfs from trying to write to non-existent sysfs file and throw exceptions on us